### PR TITLE
Make BTreeKeyIterator public

### DIFF
--- a/Sources/BTreeIterator.swift
+++ b/Sources/BTreeIterator.swift
@@ -53,10 +53,13 @@ public struct BTreeValueIterator<Value>: IteratorProtocol {
 
 /// An iterator for the keys stored in a B-tree without a value.
 public struct BTreeKeyIterator<Key: Comparable>: IteratorProtocol {
-    internal typealias Base = BTreeIterator<Key, Void>
+    public typealias Base = BTreeIterator<Key, Void>
     private var base: Base
 
-    internal init(_ base: Base) {
+	/// Initialize a key-only iterator from a key-value iterator. 
+	///
+	/// - Complexity: O(1)
+    public init(_ base: Base) {
         self.base = base
     }
 


### PR DESCRIPTION
My case for them is that I made a sorted list structure, which is basically an OrderedSet that allows duplicates. It surprised me that I wasn't able to create the same type of iterator that OrderedSet was creating, especially since it has no dependency.

I bailed out on BTreeValueIterator because it needs the `EmptyKey` structure, which is clearly an implementation detail, and it would be weird to expose an `EmptyKey` structure publicly. Of course, if the lack of symmetry is deemed a bad thing, I don't mind going back to duplicating like 10 lines of code in my project.